### PR TITLE
TASK: Upgrade dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=7.3",
-        "symfony/console": "^5.1",
-        "symfony/yaml": "^5.1"
+        "symfony/console": "^5.4",
+        "symfony/yaml": "^5.4"
     },
     "bin": [
         "yaml-splitter.php"


### PR DESCRIPTION
It is not possible to reorganize a project using the old build, as the command throws PHP deprecation warnings. 
It is also not possible to install via composer with a newer PHP version.

This adjustment updates the dependencies to version 5.4 of symfony/console and symfony/yaml, which is compatible with PHP 8.2 or 8.3 without Deprecation warnings.